### PR TITLE
Create qbcore admin menu script

### DIFF
--- a/qb-adminmenu/client.lua
+++ b/qb-adminmenu/client.lua
@@ -1,0 +1,52 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+RegisterNetEvent('qb-adminmenu:client:openMenu', function()
+    local menu = {
+        {
+            header = 'Admin Menu',
+            isMenuHeader = true
+        },
+        {
+            header = 'Teleport to Waypoint',
+            txt = 'Teleport to your current waypoint',
+            params = {
+                event = 'qb-adminmenu:client:teleportToWaypoint'
+            }
+        },
+        {
+            header = 'Revive Self',
+            txt = 'Revive yourself instantly',
+            params = {
+                isServer = false,
+                event = 'hospital:client:Revive'
+            }
+        },
+        {
+            header = 'Close',
+            txt = '',
+            params = {
+                event = 'qb-menu:closeMenu'
+            }
+        }
+    }
+
+    exports['qb-menu']:openMenu(menu)
+end)
+
+RegisterNetEvent('qb-adminmenu:client:teleportToWaypoint', function()
+    local ped = PlayerPedId()
+    local waypoint = GetFirstBlipInfoId(8)
+    if DoesBlipExist(waypoint) then
+        local coord = GetBlipInfoIdCoord(waypoint)
+        FreezeEntityPosition(ped, true)
+        SetEntityCoordsNoOffset(ped, coord.x, coord.y, coord.z, false, false, false)
+        local timeout = 0
+        while not HasCollisionLoadedAroundEntity(ped) and timeout < 5000 do
+            Wait(10)
+            timeout = timeout + 10
+        end
+        FreezeEntityPosition(ped, false)
+    else
+        QBCore.Functions.Notify('No waypoint found', 'error')
+    end
+end)

--- a/qb-adminmenu/fxmanifest.lua
+++ b/qb-adminmenu/fxmanifest.lua
@@ -1,0 +1,25 @@
+fx_version 'cerulean'
+
+game 'gta5'
+
+author 'Cursor AI'
+description 'Simple Admin Menu using qb-menu for QBCore'
+
+lua54 'yes'
+
+shared_scripts {
+    '@qb-core/shared/locale.lua'
+}
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}
+
+dependencies {
+    'qb-core',
+    'qb-menu'
+}

--- a/qb-adminmenu/server.lua
+++ b/qb-adminmenu/server.lua
@@ -1,0 +1,6 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+-- /admin command to open the admin menu (permission requirement: admin)
+QBCore.Commands.Add('admin', 'Open the admin menu', {}, false, function(source)
+    TriggerClientEvent('qb-adminmenu:client:openMenu', source)
+end, 'admin')


### PR DESCRIPTION
Add a new `qb-adminmenu` resource to provide a simple in-game admin menu via the `/admin` command.

---
<a href="https://cursor.com/background-agent?bcId=bc-ebbe0ea4-914d-4514-8869-d5ef3ce17a39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ebbe0ea4-914d-4514-8869-d5ef3ce17a39">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

